### PR TITLE
Compatibility with RestClient 2.0

### DIFF
--- a/lib/restclient/components.rb
+++ b/lib/restclient/components.rb
@@ -13,9 +13,10 @@ module RestClient
         net_http_response = RestClient::MockNetHTTPResponse.new(body, status, header)
         content = ""
         net_http_response.body.each{|line| content << line}
+        request = env['restclient.hash'][:request]
         response = case RestClient::Response.method(:create).arity
-        when 4 then RestClient::Response.create(content, net_http_response, {}, self)
-        else        RestClient::Response.create(content, net_http_response, {})
+        when 4 then RestClient::Response.create(content, net_http_response, request, self)
+        else        RestClient::Response.create(content, net_http_response, request)
         end
         if block = env['restclient.hash'][:block]
           block.call(response)


### PR DESCRIPTION
Fixes https://github.com/crohr/rest-client-components/issues/13

RestClient 2.0 has added a '#history' method to RestClient::Response and a '#redirection_history' method to RestClient::Request, to keep track of redirection chains (see https://github.com/rest-client/rest-client/commit/5e5fcd95808c288118a7b28d5e25a44ec709c62f). RestClient::Rack::Compatiblity, from rest-client-components, was passing an empty Hash to the 'request' argument of RestClient::Response.create, which raises a NoMethodError when RestClient attempts to invoke the 'redirection_history' method on the Hash object.

The fix is to pass the original request object to RestClient::Response.create. As far as I can see there was no reason to pass an empty hash instead of the actual request object.
